### PR TITLE
Add duplicate param to client

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ Currently supported libraries for agents are:
 6. WhisperAudioTranscriptionTool - A tool for transcribing audio with Whisper. Based on this [HuggingFace Space](https://huggingface.co/spaces/abidlabs/whisper)
 7. ClipInterrogatorTool - A tool for reverse engineering a prompt from a source image. Based on this [HuggingFace Space](https://huggingface.co/spaces/pharma/CLIP-Interrogator)
 8. DocQueryDocumentAnsweringTool - A tool for answering questions about a document from the from the image of the document. Based on this [HuggingFace Space](https://huggingface.co/spaces/abidlabs/docquery)
+9. BarkTextToSpeechTool - A tool for text-to-speech. Based on this [HuggingFace Space](https://huggingface.co/spaces/suno/bark)
 
 We welcome more contributions!
 

--- a/gradio_tools/__init__.py
+++ b/gradio_tools/__init__.py
@@ -1,4 +1,4 @@
-from gradio_tools.tools import (ClipInterrogatorTool,
+from gradio_tools.tools import (BarkTextToSpeechTool, ClipInterrogatorTool,
                                 DocQueryDocumentAnsweringTool, GradioTool,
                                 ImageCaptioningTool, ImageToMusicTool,
                                 StableDiffusionPromptGeneratorTool,
@@ -15,4 +15,5 @@ __all__ = [
     "StableDiffusionPromptGeneratorTool",
     "TextToVideoTool",
     "DocQueryDocumentAnsweringTool",
+    "BarkTextToSpeechTool",
 ]

--- a/gradio_tools/tools/bark.py
+++ b/gradio_tools/tools/bark.py
@@ -57,8 +57,9 @@ class BarkTextToSpeechTool(GradioTool):
         ),
         src="suno/bark",
         hf_token=None,
+        duplicate=False,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         try:

--- a/gradio_tools/tools/clip_interrogator.py
+++ b/gradio_tools/tools/clip_interrogator.py
@@ -19,8 +19,9 @@ class ClipInterrogatorTool(GradioTool):
         ),
         src="pharma/CLIP-Interrogator",
         hf_token=None,
+        duplicate=True,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(

--- a/gradio_tools/tools/document_qa.py
+++ b/gradio_tools/tools/document_qa.py
@@ -18,8 +18,9 @@ class DocQueryDocumentAnsweringTool(GradioTool):
         ),
         src="abidlabs/docquery",
         hf_token=None,
+        duplicate=True,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         img, question = query.split(",")

--- a/gradio_tools/tools/gradio_tool.py
+++ b/gradio_tools/tools/gradio_tool.py
@@ -19,16 +19,21 @@ except (ModuleNotFoundError, ImportError):
 
 class GradioTool:
     def __init__(
-        self, name: str, description: str, src: str, hf_token: str | None = None
+        self,
+        name: str,
+        description: str,
+        src: str,
+        hf_token: str | None = None,
+        duplicate: bool = True,
     ) -> None:
         self.name = name
         self.description = description
-        if hf_token and self._is_space(src):
+        if hf_token and self._is_space(src) and duplicate:
             self.client = grc.Client.duplicate(from_id=src, hf_token=hf_token)
             self.src = self.client.space_id
         else:
             self.src = src
-            self.client = grc.Client(self.src)
+            self.client = grc.Client(self.src, hf_token=hf_token)
         self.description += (
             "If the output is the string QUEUE_FULL you "
             "should try this action again and never stop until you "

--- a/gradio_tools/tools/image_captioning.py
+++ b/gradio_tools/tools/image_captioning.py
@@ -23,8 +23,9 @@ class ImageCaptioningTool(GradioTool):
         ),
         src="taesiri/BLIP-2",
         hf_token=None,
+        duplicate=True,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(query.strip("'"), "Beam Search", fn_index=0)

--- a/gradio_tools/tools/image_to_music.py
+++ b/gradio_tools/tools/image_to_music.py
@@ -19,8 +19,9 @@ class ImageToMusicTool(GradioTool):
         ),
         src="fffiloni/img-to-music",
         hf_token=None,
+        duplicate=False,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(

--- a/gradio_tools/tools/prompt_generator.py
+++ b/gradio_tools/tools/prompt_generator.py
@@ -17,8 +17,9 @@ class StableDiffusionPromptGeneratorTool(GradioTool):
         ),
         src="microsoft/Promptist",
         hf_token=None,
+        duplicate=False,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(query, api_name="/predict")

--- a/gradio_tools/tools/stable_diffusion.py
+++ b/gradio_tools/tools/stable_diffusion.py
@@ -24,8 +24,9 @@ class StableDiffusionTool(GradioTool):
         ),
         src="gradio-client-demos/stable-diffusion",
         hf_token=None,
+        duplicate=False,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(query, "", 9, fn_index=1)

--- a/gradio_tools/tools/text_to_video.py
+++ b/gradio_tools/tools/text_to_video.py
@@ -20,8 +20,9 @@ class TextToVideoTool(GradioTool):
         ),
         src="damo-vilab/modelscope-text-to-video-synthesis",
         hf_token=None,
+        duplicate=False,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(query, -1, 16, 25, fn_index=1)

--- a/gradio_tools/tools/whisper.py
+++ b/gradio_tools/tools/whisper.py
@@ -21,8 +21,9 @@ class WhisperAudioTranscriptionTool(GradioTool):
         ),
         src="abidlabs/whisper",
         hf_token=None,
+        duplicate=False,
     ) -> None:
-        super().__init__(name, description, src, hf_token)
+        super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
         return self.client.submit(query, api_name="/predict")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,7 @@ dependencies = [
 minichain = ["gradio", "minichain>=0.3.3"]
 langchain = ["langchain", "openai"]
 all = ["gradio_tools[langchain]", "gradio_tools[minichain]"]
-test = ["ruff==0.0.260", "pyright==1.1.298", "isort >=5.0.6,<6.0.0", "black==22.6.0"]
+test = ["ruff==0.0.260", "pyright==1.1.298", "isort >=5.0.6,<6.0.0", "black==22.6.0", "pytest"]
 dev = ["gradio_tools[all]", "gradio_tools[test]"]
 
 [tool.hatch.metadata.hooks.fancy-pypi-readme]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -1,0 +1,24 @@
+import pytest
+from unittest.mock import patch
+
+import gradio_tools
+from gradio_tools import GradioTool
+
+
+@pytest.mark.parametrize("tool_class", GradioTool.__subclasses__())
+@patch("gradio_client.Client.duplicate")
+def test_duplicate(mock_duplicate, tool_class):
+    tool_class(duplicate=True, hf_token="dafsdf")
+    mock_duplicate.assert_called_once()
+
+
+@pytest.mark.parametrize("tool_class", GradioTool.__subclasses__())
+@patch("gradio_client.Client.duplicate")
+def test_dont_duplicate(mock_duplicate, tool_class):
+    tool_class(duplicate=False)
+    mock_duplicate.assert_not_called()
+
+
+@pytest.mark.parametrize("tool_class", GradioTool.__subclasses__())
+def test_all_listed_in_init(tool_class):
+    assert tool_class.__name__ in gradio_tools.__all__


### PR DESCRIPTION
The previous logic would always duplicate a space if hf_token was present but that's not always the right thing to do. 
For example, you may want to use a private space for your tool and simply need to pass the token to authenticate.

Also added bark to the README 