### PR TITLE
Return block_input and block_output as list

### DIFF
--- a/gradio_tools/__init__.py
+++ b/gradio_tools/__init__.py
@@ -1,10 +1,10 @@
 from gradio_tools.tools import (BarkTextToSpeechTool, ClipInterrogatorTool,
                                 DocQueryDocumentAnsweringTool, GradioTool,
                                 ImageCaptioningTool, ImageToMusicTool,
+                                SAMImageSegmentationTool,
                                 StableDiffusionPromptGeneratorTool,
                                 StableDiffusionTool, TextToVideoTool,
-                                WhisperAudioTranscriptionTool,
-                                SAMImageSegmentationTool)
+                                WhisperAudioTranscriptionTool)
 
 __all__ = [
     "GradioTool",
@@ -17,5 +17,5 @@ __all__ = [
     "TextToVideoTool",
     "DocQueryDocumentAnsweringTool",
     "BarkTextToSpeechTool",
-    "SAMImageSegmentationTool"
+    "SAMImageSegmentationTool",
 ]

--- a/gradio_tools/tools/__init__.py
+++ b/gradio_tools/tools/__init__.py
@@ -6,10 +6,10 @@ from gradio_tools.tools.image_captioning import ImageCaptioningTool
 from gradio_tools.tools.image_to_music import ImageToMusicTool
 from gradio_tools.tools.prompt_generator import \
     StableDiffusionPromptGeneratorTool
+from gradio_tools.tools.sam_with_clip import SAMImageSegmentationTool
 from gradio_tools.tools.stable_diffusion import StableDiffusionTool
 from gradio_tools.tools.text_to_video import TextToVideoTool
 from gradio_tools.tools.whisper import WhisperAudioTranscriptionTool
-from gradio_tools.tools.sam_with_clip import SAMImageSegmentationTool
 
 __all__ = [
     "GradioTool",
@@ -22,5 +22,5 @@ __all__ = [
     "TextToVideoTool",
     "DocQueryDocumentAnsweringTool",
     "BarkTextToSpeechTool",
-    "SAMImageSegmentationTool"
+    "SAMImageSegmentationTool",
 ]

--- a/gradio_tools/tools/bark.py
+++ b/gradio_tools/tools/bark.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
@@ -80,8 +80,8 @@ class BarkTextToSpeechTool(GradioTool):
     def postprocess(self, output: str) -> str:
         return output
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Textbox()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Textbox()]
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Audio()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Audio()]

--- a/gradio_tools/tools/clip_interrogator.py
+++ b/gradio_tools/tools/clip_interrogator.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
@@ -31,5 +31,5 @@ class ClipInterrogatorTool(GradioTool):
     def postprocess(self, output: str) -> str:
         return output
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Image()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Image()]

--- a/gradio_tools/tools/document_qa.py
+++ b/gradio_tools/tools/document_qa.py
@@ -1,9 +1,8 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
 from gradio_tools.tools.gradio_tool import GradioTool
-from typing import List
 
 if TYPE_CHECKING:
     import gradio as gr

--- a/gradio_tools/tools/document_qa.py
+++ b/gradio_tools/tools/document_qa.py
@@ -3,6 +3,7 @@ from typing import TYPE_CHECKING
 from gradio_client.client import Job
 
 from gradio_tools.tools.gradio_tool import GradioTool
+from typing import List
 
 if TYPE_CHECKING:
     import gradio as gr
@@ -13,7 +14,7 @@ class DocQueryDocumentAnsweringTool(GradioTool):
         self,
         name="DocQuery",
         description=(
-            "A tool for answering questions about a document from the from the image of the document. Input will be a two strings separated by a comma: the first will be the path or URL to an image of a document. The second will be your question about the document."
+            "A tool for answering questions about a document from the from the image of the document. Input will be a two strings separated by a |: the first will be the path or URL to an image of a document. The second will be your question about the document."
             "The output will the text answer to your question."
         ),
         src="abidlabs/docquery",
@@ -23,11 +24,11 @@ class DocQueryDocumentAnsweringTool(GradioTool):
         super().__init__(name, description, src, hf_token, duplicate)
 
     def create_job(self, query: str) -> Job:
-        img, question = query.split(",")
+        img, question = query.split("|")
         return self.client.submit(img.strip(), question.strip(), api_name="/predict")
 
     def postprocess(self, output: str) -> str:
         return output
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Image()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Image(), gr.Textbox()]

--- a/gradio_tools/tools/gradio_tool.py
+++ b/gradio_tools/tools/gradio_tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from abc import abstractmethod
-from typing import Any, Tuple, Union
+from typing import Any, Tuple, Union, List
 
 import gradio_client as grc
 import huggingface_hub
@@ -70,13 +70,13 @@ class GradioTool:
         return output
 
     # Optional gradio functionalities
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Textbox()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Textbox()]
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Textbox()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Textbox()]
 
-    def block_input(self) -> "gr.components.Component":
+    def block_input(self) -> List["gr.components.Component"]:
         try:
             import gradio as gr
 
@@ -88,7 +88,7 @@ class GradioTool:
         else:
             return self._block_input(gr)
 
-    def block_output(self) -> "gr.components.Component":
+    def block_output(self) -> List["gr.components.Component"]:
         try:
             import gradio as gr
 

--- a/gradio_tools/tools/gradio_tool.py
+++ b/gradio_tools/tools/gradio_tool.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 import time
 from abc import abstractmethod
-from typing import Any, Tuple, Union, List
+from typing import Any, List, Tuple, Union
 
 import gradio_client as grc
 import huggingface_hub

--- a/gradio_tools/tools/image_captioning.py
+++ b/gradio_tools/tools/image_captioning.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
@@ -21,7 +21,7 @@ class ImageCaptioningTool(GradioTool):
             "Input will be a path to an image file. "
             "The output will be a caption of that image."
         ),
-        src="taesiri/BLIP-2",
+        src="gradio-client-demos/BLIP-2",
         hf_token=None,
         duplicate=True,
     ) -> None:
@@ -33,8 +33,8 @@ class ImageCaptioningTool(GradioTool):
     def postprocess(self, output: str) -> str:
         return output  # type: ignore
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Image()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Image()]
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Textbox()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Textbox()]

--- a/gradio_tools/tools/image_to_music.py
+++ b/gradio_tools/tools/image_to_music.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple, Union
+from typing import TYPE_CHECKING, Any, Tuple, Union, List
 
 from gradio_client.client import Job
 
@@ -31,8 +31,8 @@ class ImageToMusicTool(GradioTool):
     def postprocess(self, output: Union[Tuple[Any], Any]) -> str:
         return output[1]  # type: ignore
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Image()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Image()]
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Audio()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Audio()]

--- a/gradio_tools/tools/image_to_music.py
+++ b/gradio_tools/tools/image_to_music.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING, Any, Tuple, Union, List
+from typing import TYPE_CHECKING, Any, List, Tuple, Union
 
 from gradio_client.client import Job
 

--- a/gradio_tools/tools/sam_with_clip.py
+++ b/gradio_tools/tools/sam_with_clip.py
@@ -10,7 +10,6 @@ if TYPE_CHECKING:
     import gradio as gr
 
 
-
 class SAMImageSegmentationTool(GradioTool):
     """Tool for segmenting images based on natural language queries."""
 
@@ -36,14 +35,26 @@ class SAMImageSegmentationTool(GradioTool):
 
     def create_job(self, query: str) -> Job:
         try:
-            image, query, predicted_iou_threshold, stability_score_threshold, clip_threshold = query.split("|")
+            (
+                image,
+                query,
+                predicted_iou_threshold,
+                stability_score_threshold,
+                clip_threshold,
+            ) = query.split("|")
         except ValueError as e:
-            raise ValueError("Not enough arguments passed to the SAMImageSegmentationTool! " 
-                             "Expected 5 (image, query, predicted_iou_threshold, stability_score_threshold, clip_threshold)") from e
-        return self.client.submit(float(predicted_iou_threshold),
-                                  float(stability_score_threshold),
-                                  float(clip_threshold),
-                                  image, query.strip(), api_name="/predict")
+            raise ValueError(
+                "Not enough arguments passed to the SAMImageSegmentationTool! "
+                "Expected 5 (image, query, predicted_iou_threshold, stability_score_threshold, clip_threshold)"
+            ) from e
+        return self.client.submit(
+            float(predicted_iou_threshold),
+            float(stability_score_threshold),
+            float(clip_threshold),
+            image,
+            query.strip(),
+            api_name="/predict",
+        )
 
     def postprocess(self, output: str) -> str:
         return output

--- a/gradio_tools/tools/sam_with_clip.py
+++ b/gradio_tools/tools/sam_with_clip.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
@@ -48,8 +48,8 @@ class SAMImageSegmentationTool(GradioTool):
     def postprocess(self, output: str) -> str:
         return output
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Textbox()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Number(), gr.Number(), gr.Number(), gr.Image(), gr.Textbox()]
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Audio()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Image()]

--- a/gradio_tools/tools/stable_diffusion.py
+++ b/gradio_tools/tools/stable_diffusion.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Tuple
+from typing import TYPE_CHECKING, Any, Tuple, List
 
 from gradio_client.client import Job
 
@@ -39,8 +39,8 @@ class StableDiffusionTool(GradioTool):
             if not i.endswith("json")
         ][0]
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Textbox()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Textbox()]
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Image()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Image()]

--- a/gradio_tools/tools/stable_diffusion.py
+++ b/gradio_tools/tools/stable_diffusion.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 import os
-from typing import TYPE_CHECKING, Any, Tuple, List
+from typing import TYPE_CHECKING, Any, List, Tuple
 
 from gradio_client.client import Job
 

--- a/gradio_tools/tools/text_to_video.py
+++ b/gradio_tools/tools/text_to_video.py
@@ -1,4 +1,4 @@
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
@@ -30,5 +30,5 @@ class TextToVideoTool(GradioTool):
     def postprocess(self, output: str) -> str:
         return output
 
-    def _block_output(self, gr) -> "gr.components.Component":
-        return gr.Video()
+    def _block_output(self, gr) -> List["gr.components.Component"]:
+        return [gr.Video()]

--- a/gradio_tools/tools/whisper.py
+++ b/gradio_tools/tools/whisper.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, List
 
 from gradio_client.client import Job
 
@@ -31,5 +31,5 @@ class WhisperAudioTranscriptionTool(GradioTool):
     def postprocess(self, output: str) -> str:
         return output
 
-    def _block_input(self, gr) -> "gr.components.Component":
-        return gr.Audio()
+    def _block_input(self, gr) -> List["gr.components.Component"]:
+        return [gr.Audio()]

--- a/tests/test_tools.py
+++ b/tests/test_tools.py
@@ -4,6 +4,12 @@ from unittest.mock import patch
 import gradio_tools
 from gradio_tools import GradioTool
 
+try:
+    import gradio as gr
+    GRADIO_INSTALLED = True
+except:
+    GRADIO_INSTALLED = False
+
 
 @pytest.mark.parametrize("tool_class", GradioTool.__subclasses__())
 @patch("gradio_client.Client.duplicate")
@@ -22,3 +28,45 @@ def test_dont_duplicate(mock_duplicate, tool_class):
 @pytest.mark.parametrize("tool_class", GradioTool.__subclasses__())
 def test_all_listed_in_init(tool_class):
     assert tool_class.__name__ in gradio_tools.__all__
+
+
+@pytest.mark.skipif(not GRADIO_INSTALLED, reason="Gradio not installed")
+@pytest.mark.parametrize("tool_class", GradioTool.__subclasses__())
+def test_input_output(tool_class):
+    if tool_class.__name__ == "BarkTextToSpeechTool":
+        inp = [gr.Textbox()]
+        output = [gr.Audio()]
+    elif tool_class.__name__ == "ClipInterrogatorTool":
+        inp = [gr.Image()]
+        output = [gr.Textbox()]
+    elif tool_class.__name__ == "DocQueryDocumentAnsweringTool":
+        inp = [gr.Image(), gr.Textbox()]
+        output = [gr.Textbox()]
+    elif tool_class.__name__ == "ImageCaptioningTool":
+        inp = [gr.Image()]
+        output = [gr.Textbox()]
+    elif tool_class.__name__ == "ImageToMusicTool":
+        inp = [gr.Image()]
+        output = [gr.Audio()]
+    elif tool_class.__name__ == "StableDiffusionPromptGeneratorTool":
+        inp = [gr.Textbox()]
+        output = [gr.Textbox()]
+    elif tool_class.__name__ == "SAMImageSegmentationTool":
+        inp = [gr.Number(), gr.Number(), gr.Number(), gr.Image(), gr.Textbox()]
+        output = [gr.Image()]
+    elif tool_class.__name__ == "StableDiffusionTool":
+        inp = [gr.Textbox()]
+        output = [gr.Image()]
+    elif tool_class.__name__ == "TextToVideoTool":
+        inp = [gr.Textbox()]
+        output = [gr.Video()]
+    elif tool_class.__name__ == "WhisperAudioTranscriptionTool":
+        inp = [gr.Audio()]
+        output = [gr.Textbox()]
+    else:
+        raise ValueError(f"Test does not have a case for: {tool_class.__name__}")
+    
+    tool = tool_class()
+    assert [t.__class__ for t in tool.block_input()] == [t.__class__ for t in inp]
+    assert [t.__class__ for t in tool.block_output()] == [t.__class__ for t in output]
+


### PR DESCRIPTION
To support cases of multiple input and output components. 

Right now all tools have one output component. 

In the case of multiple input components, they are separated by a pipe character `|` in the query given by the agent.

CC @lysandrejik @srush 